### PR TITLE
Backend/fix converter multiprocessing

### DIFF
--- a/backend/converter.py
+++ b/backend/converter.py
@@ -177,7 +177,7 @@ class GenImage():
             pdf_bytes: bytes
                 An array of bytes that may contain a pdf
         '''
-        images = convert_from_bytes(pdf_bytes)
+        images = convert_from_bytes(pdf_bytes, thread_count=100)
         sum_width = sum([img.width for img in images])
         max_height = max([img.height for img in images])
         # Create empty image for pasting

--- a/backend/converter.py
+++ b/backend/converter.py
@@ -9,6 +9,7 @@ import base64
 import io
 import tempfile
 import os
+import pathlib
 import zipfile
 
 
@@ -136,8 +137,9 @@ class GenImage():
                 An array of bytes that may contain a pptx
         '''
         with tempfile.TemporaryDirectory() as tmpdir:
-            pptx_path = os.path.join(tmpdir, "presentation.pptx")
-            pdf_path = os.path.join(tmpdir, "presentation.pdf")
+            tmpdir_path = pathlib.Path(tmpdir)
+            pptx_path = tmpdir_path.joinpath("presentation.pptx")
+            pdf_path = tmpdir_path.joinpath("presentation.pdf")
 
             with open(pptx_path, "wb") as f:
                 f.write(pptx_bytes)
@@ -149,6 +151,7 @@ class GenImage():
             subprocess.run([
                 "libreoffice",
                 "--headless",
+                f"-env:UserInstallation={tmpdir_path.as_uri()}",
                 "--convert-to", "pdf",
                 "--outdir", tmpdir,
                 pptx_path

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest==8.3.5
 pytest-cov==6.1.1
+pytest-asyncio==0.26.0

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -9,6 +9,7 @@ from pptx.util import Inches, Pt
 from pptx.dml.color import RGBColor
 import tempfile
 import os
+import asyncio
 
 def create_simple_presentation(output_path):
     '''
@@ -89,3 +90,13 @@ def test_fonts_parsing_from_sample_pptx(sample_pptx_bytes):
     # Checking for Arial in the fonts of the second slide
     all_fonts = [font for fonts in gen.fonts.values() for font in fonts]
     assert any("Arial" in font for font in all_fonts if font)
+
+async def async_convert(sample_pptx_bytes):
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, GenImage, sample_pptx_bytes, "pptx")
+
+@pytest.mark.asyncio
+async def test_asyncio_parallel(sample_pptx_bytes):
+    tasks = [async_convert(sample_pptx_bytes) for _ in range(3)]
+    results = await asyncio.gather(*tasks)
+    assert all(len(r.default_fonts) > 0 for r in results)


### PR DESCRIPTION
Resolves #6. Added a path for the user interface to run multiple instances of libreoffice. Added test of the possibility of multiprocessor conversion.
Minor changes to pdf to image to speed up the conversion.